### PR TITLE
Migrate to React 0.14 APIs

### DIFF
--- a/_webpack.dist.config.js
+++ b/_webpack.dist.config.js
@@ -17,6 +17,12 @@ module.exports = {
       commonjs: 'react',
       commonjs2: 'react',
       amd: 'react'
+    },
+    'react-dom': {
+      root: 'ReactDOM',
+      commonjs: 'react-dom',
+      commonjs2: 'react-dom',
+      amd: 'react-dom'
     }
   }
 };

--- a/demo/demo.jsx
+++ b/demo/demo.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import domready from 'domready';
 import Popout from '../lib/react-popout.jsx';
 
@@ -57,5 +58,5 @@ class Example extends React.Component {
 domready(() => {
   var container = document.createElement('div');
   document.body.appendChild(container);
-  React.render(<Example />, container);
+  ReactDOM.render(<Example />, container);
 });

--- a/lib/react-popout.jsx
+++ b/lib/react-popout.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import assign from 'lodash.assign';
 import isFunction from 'lodash.isfunction';
 import reduce from 'lodash.reduce';
@@ -57,7 +58,7 @@ export default class PopoutWindow extends React.Component {
     win = ownerWindow.open(this.props.url || 'about:blank', this.props.title, optionsString);
     win.onbeforeunload = () => {
       if (container) {
-        React.unmountComponentAtNode(container);
+        ReactDOM.unmountComponentAtNode(container);
       }
       this.windowClosing();
     };
@@ -67,7 +68,7 @@ export default class PopoutWindow extends React.Component {
       if (container) {
         var existing = win.document.getElementById(divId);
         if (!existing){
-          React.unmountComponentAtNode(container);
+          ReactDOM.unmountComponentAtNode(container);
           container = null;
         } else{
           return;
@@ -78,9 +79,9 @@ export default class PopoutWindow extends React.Component {
       container = win.document.createElement('div');
       container.id = divId;
       win.document.body.appendChild(container);
-      React.render(this.props.children, container);
+      ReactDOM.render(this.props.children, container);
       api.update = newComponent => {
-        React.render(newComponent, container);
+        ReactDOM.render(newComponent, container);
       };
       api.close = () => win.close();
     };

--- a/package.json
+++ b/package.json
@@ -45,8 +45,5 @@
     "mocha": "^2.2.5",
     "node-libs-browser": "^0.5.2",
     "webpack": "^1.9.10"
-  },
-  "peerDependencies": {
-    "react": "^0.13.3"
   }
 }


### PR DESCRIPTION
- Support React core / ReactDOM renderer split
- Remove react from peerDependencies since peerDeps are deprecated and it makes current and future react upgrade paths unnecessarily painful
