### PR TITLE
Add support for `postMessage` in the child window.

### DIFF
--- a/lib/react-popout.jsx
+++ b/lib/react-popout.jsx
@@ -62,6 +62,11 @@ export default class PopoutWindow extends React.Component {
       }
       this.windowClosing();
     };
+    if (this.props.onMessage) {
+      win.onmessage = (event) => {
+        this.props.onMessage(event);
+      }
+    }
     var onloadHandler = () => {
       // Some browsers don't call onload in some cases for popup windows (looking at you firefox).
       // If anyone wants to make this better, that would be awesome
@@ -118,6 +123,7 @@ PopoutWindow.propTypes = {
   title: React.PropTypes.string.isRequired,
   url: React.PropTypes.string,
   onClosing: React.PropTypes.func,
+  onMessage: React.PropTypes.func,
   options: React.PropTypes.object,
   window: React.PropTypes.object
 };


### PR DESCRIPTION
Hi, thanks for this component, it is a cool solution to popup windows in React. We have a use case whereby we are in the process of porting an application to React, and so the `PopoutWindow` will have some react components in it, but primarily it is hosting an `<iframe>` with some legacy code in there. The cleanest way to get our legacy code to talk to the larger React application is by invoking `window.top.postMessage(...)` from within the legacy `<iframe>`, and having the application which opened the `PopoutWindow` listen for that message.

This PR adds support for an `onMessage` listener to the `PopoutWindow`. It can be used like so:

```
<PopoutWindow onMessage={this.doSomething} />
```

Where the callback is invoked with the event which `window.onmessage` received from within the `PopoutWindow`.
